### PR TITLE
Remove application from library manifest.

### DIFF
--- a/EasyFlipView/src/main/AndroidManifest.xml
+++ b/EasyFlipView/src/main/AndroidManifest.xml
@@ -1,7 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.wajahatkarim3.easyflipview">
-
-    <application android:allowBackup="true"
-        android:supportsRtl="true"/>
-
-</manifest>
+<manifest package="com.wajahatkarim3.easyflipview"/>


### PR DESCRIPTION
The library should not specify anything related to applications.

Currently, due to the `android:allowBackup="true"`, applications that don't want to allow backups need to override this behaviour by adding `tools:replace="android:allowBackup"` to the application Manifest.