### PR TITLE
Moved EasyFlipView to MavenCentral

### DIFF
--- a/.github/publish_to_maven_central.yml
+++ b/.github/publish_to_maven_central.yml
@@ -1,0 +1,38 @@
+name: Publish
+on:
+  release:
+    # We'll run this workflow when a new GitHub release is created
+    types: [released]
+
+jobs:
+  publish:
+    name: Release build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 11
+
+        # Builds the release artifacts of the library
+      - name: Release build
+        run: ./gradlew :stream-chat-android-client:assembleRelease
+
+        # Generates other artifacts (javadocJar is optional)
+      - name: Source jar and dokka
+        run: ./gradlew androidSourcesJar javadocJar
+
+        # Runs upload, and then closes & releases the repository
+      - name: Publish to MavenCentral
+        run: ./gradlew publishReleasePublicationToSonatypeRepository --max-workers 1 closeAndReleaseSonatypeStagingRepository
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/EasyFlipView/build.gradle
+++ b/EasyFlipView/build.gradle
@@ -1,35 +1,19 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.jfrog.bintray'
-apply plugin: 'com.github.dcendents.android-maven'
 
 ext {
-    /*
-    PUBLISH_GROUP_ID = 'com.wajahatkarim3.EasyFlipView'
+    PUBLISH_GROUP_ID = 'com.wajahatkarim'
     PUBLISH_ARTIFACT_ID = 'EasyFlipView'
-    PUBLISH_VERSION = '3.0.0'
-    */
-
-    bintrayRepo = "EasyFlipView"
-    bintrayName = "com.wajahatkarim3.EasyFlipView"
-
-    publishedGroupId = 'com.wajahatkarim3.EasyFlipView'
-    libraryName = 'EasyFlipView'
-    artifact = 'EasyFlipView'
-
-    libraryDescription = 'A quick and easy flip view through which you can create views with two sides like credit cards, poker cards etc.'
-
-    siteUrl = 'https://github.com/wajahatkarim3/EasyFlipView'
-    gitUrl = 'https://github.com/wajahatkarim3/EasyFlipView.git'
-
-    libraryVersion = '3.0.0'
-
-    developerId = 'wajahatkarim3'
-    developerName = 'Wajahat Karim'
-    developerEmail = 'wajahatkarim3@gmail.com'
-
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ["Apache-2.0"]
+    PUBLISH_VERSION = '3.0.3'
+    PUBLISH_DESCRIPTION = 'A quick and easy flip view through which you can create views with two sides like credit cards, poker cards etc.'
+    PUBLISH_URL = 'https://github.com/wajahatkarim3/EasyFlipView'
+    PUBLISH_LICENSE_NAME = 'Apache License'
+    PUBLISH_LICENSE_URL = 'https://github.com/wajahatkarim3/EasyFlipView/blob/master/LICENSE'
+    PUBLISH_DEVELOPER_ID = 'wajahatkarim'
+    PUBLISH_DEVELOPER_NAME = 'Wajahat Karim'
+    PUBLISH_DEVELOPER_EMAIL = 'wajahatkarim3@mail.com'
+    PUBLISH_SCM_CONNECTION = 'scm:git:github.com/wajahatkarim3/EasyFlipView.git'
+    PUBLISH_SCM_DEVELOPER_CONNECTION = 'scm:git:ssh://github.com/wajahatkarim3/EasyFlipView.git'
+    PUBLISH_SCM_URL = 'https://github.com/wajahatkarim3/EasyFlipView/tree/master'
 }
 
 android {
@@ -66,15 +50,4 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-// or use the remote copy to keep update with latest changes
-//apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'
-
-//apply from: 'android-release-aar.gradle'
-//apply from: 'https://raw.githubusercontent.com/blundell/release-android-library/master/android-release-aar.gradle'
-
-//Add these lines to publish library to bintray. This is the readymade scripts made by github user nuuneoi to make uploading to bintray easy.
-//Place it at the end of the file
-if (project.rootProject.file('local.properties').exists()) {
-    apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'
-    apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/bintrayv1.gradle'
-}
+apply from: "${rootDir}/scripts/publish-module.gradle"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Changes exist in the [releases](https://github.com/wajahatkarim3/EasyFlipView/re
 Add this in your app's `build.gradle` file:
 ```groovy
 dependencies {
-  implementation 'com.wajahatkarim3.EasyFlipView:EasyFlipView:3.0.0'
+  implementation 'com.wajahatkarim:EasyFlipView:3.0.3'
 }
 ```
 
@@ -40,9 +40,9 @@ Or add EasyFlipView as a new dependency inside your pom.xml
 
 ```xml
 <dependency> 
-  <groupId>com.wajahatkarim3.EasyFlipView</groupId>
+  <groupId>com.wajahatkarim</groupId>
   <artifactId>EasyFlipView</artifactId> 
-  <version>3.0.0</version>
+  <version>3.0.3</version>
   <type>pom</type> 
 </dependency>
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -3,24 +3,28 @@ buildscript {
     ext.supportVersion = '28.0.0'
 
     repositories {
+        maven { url "https://plugins.gradle.org/m2/" }
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
     }
 }
+
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
+
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
 task clean(type: Delete) {
     delete rootProject.buildDir
 }
+apply from: "${rootDir}/scripts/publish-root.gradle"

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -1,0 +1,84 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+task androidSourcesJar(type: Jar) {
+    archiveClassifier.set('sources')
+    if (project.plugins.findPlugin("com.android.library")) {
+        // For Android libraries
+        from android.sourceSets.main.java.srcDirs
+//        from android.sourceSets.main.kotlin.srcDirs
+    } else {
+        // For pure Kotlin libraries, in case you have them
+        from sourceSets.main.java.srcDirs
+//        from sourceSets.main.kotlin.srcDirs
+    }
+}
+
+artifacts {
+    archives androidSourcesJar
+}
+
+group = PUBLISH_GROUP_ID
+version = PUBLISH_VERSION
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // The coordinates of the library, being set from variables that
+                // we'll set up later
+                groupId PUBLISH_GROUP_ID
+                artifactId PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
+                // Two artifacts, the `aar` (or `jar`) and the sources
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.release
+                } else {
+                    from components.java
+                }
+
+                artifact androidSourcesJar
+//                artifact javadocJar
+
+                // Mostly self-explanatory metadata
+                pom {
+                    name = PUBLISH_ARTIFACT_ID
+                    description = PUBLISH_DESCRIPTION
+                    url = PUBLISH_URL
+                    licenses {
+                        license {
+                            name = PUBLISH_LICENSE_NAME
+                            url = PUBLISH_LICENSE_URL
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = PUBLISH_DEVELOPER_ID
+                            name = PUBLISH_DEVELOPER_NAME
+                            email = PUBLISH_DEVELOPER_EMAIL
+                        }
+                        // Add all other devs here...
+                    }
+
+                    // Version control info - if you're using GitHub, follow the
+                    // format as seen here
+                    scm {
+                        connection = PUBLISH_SCM_CONNECTION
+                        developerConnection = PUBLISH_SCM_DEVELOPER_CONNECTION
+                        url = PUBLISH_SCM_URL
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+            rootProject.ext["signing.keyId"],
+            rootProject.ext["signing.key"],
+            rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
+}

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -1,0 +1,39 @@
+// Create variables with empty default values
+// Create variables with empty default values
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.key"] = ''
+ext["snapshot"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    // Read local.properties file first if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.key"] = System.getenv('SIGNING_KEY')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            // Add these lines if using new Sonatype infra
+            // nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            // snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}


### PR DESCRIPTION
The `EasyFlipView` has been moved successfully from `jCenter` to `MavenCentral`.

You can use the library using the following Gradle depenency:

```groovy
implementation 'com.wajahatkarim:EasyFlipView:3.0.3'
```